### PR TITLE
Automate release creation

### DIFF
--- a/.github/create_rel.sh
+++ b/.github/create_rel.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+pkgv=$(cargo pkgid | awk -F'[ #]' '{print "v"$2}')
+
+ghv=$(gh release list -L 1 | awk -F" " '{print $1}')
+
+# compare versions
+if [[ $pkgv != $ghv ]]; then
+    echo "'$pkgv' != '$ghv' ... creating new release tag"
+    # create new rel tag
+    url=$(gh release create "$pkgv"  --repo="$GITHUB_REPOSITORY" --title="$pkgv" --target="$GITHUB_SHA" --generate-notes)
+    echo "new release created at: $url"
+    echo "created=1" >> $GITHUB_OUTPUT
+else
+    echo "$pkgv == $ghv ... stopping"
+    echo "created=0" >> $GITHUB_OUTPUT
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+on:
+  workflow_run:
+    workflows:
+      - 'tests'
+    types:
+      - 'completed'
+    branches:
+      - 'main'
+
+name: Create Release
+permissions:
+  contents: write
+
+jobs:
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      created: ${{ steps.create_release_step.outputs.created }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: "cargo check"
+        run: |
+          cargo check
+
+      - name: "create release"
+        id: create_release_step
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash .github/create_rel.sh
+
+  crates_io_publish:
+    name: Publish (crates.io)
+    needs: create_release
+    if: needs.create_release.outputs.created == 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: cargo-release Cache
+        id: cargo_release_cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/cargo-release
+          key: ${{ runner.os }}-cargo-release
+
+      - run: cargo install cargo-release
+        if: steps.cargo_release_cache.outputs.cache-hit != 'true'
+
+      - name: cargo login
+        run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+
+      - name: "cargo release publish"
+        run: |-
+          cargo release \
+            publish \
+            --workspace \
+            --all-features \
+            --allow-branch main \
+            --no-confirm \
+            --execute


### PR DESCRIPTION
What
--
Automate release creation

Automatically create a release and publish to crates.io when the version is bumped.